### PR TITLE
Switch to QGraphicsWebView to support CSS 3D transforms

### DIFF
--- a/examples/css_3d_transforms.py
+++ b/examples/css_3d_transforms.py
@@ -55,6 +55,10 @@ body_html = """
           -webkit-transition: -webkit-transform 1s;
         }
 
+        #card.flipped {
+          -webkit-transform: rotateY( 180deg );
+        }
+
         #card .face {
           display: block;
           position: absolute;
@@ -73,10 +77,6 @@ body_html = """
           background: blue;
           -webkit-transform: rotateY( 180deg );
         }
-
-        #card.flipped {
-          -webkit-transform: rotateY( 180deg );
-        }
     </style>
 """
 
@@ -93,9 +93,7 @@ def main():
 
     # Create a jigna based HTML widget to render the HTML template with the
     # given context.
-    widget = HTMLWidget(
-        template=template, context={'card': card}
-    )
+    widget = HTMLWidget(template=template, context={'card': card})
     widget.show()
 
     # Start the event loop

--- a/examples/css_3d_transforms.py
+++ b/examples/css_3d_transforms.py
@@ -1,0 +1,109 @@
+"""
+This example shows that the jigna HTML view supports CSS 3D transforms, a
+property of the underlying QGraphicsWebView item.
+
+Card flip CSS source: http://desandro.github.io/3dtransforms/docs/card-flip.html
+"""
+
+#### Imports ####
+
+from jigna.api import HTMLWidget, Template
+from jigna.qt import QtGui
+from traits.api import HasTraits, Enum
+
+#### Domain model ####
+
+class Card(HasTraits):
+    visible_face = Enum('front', 'back')
+
+    def flip(self):
+        if self.visible_face == 'front':
+            self.visible_face = 'back'
+
+        else:
+            self.visible_face = 'front'
+
+
+#### UI layer ####
+
+body_html = """
+    <div class="container">
+      <div id="card"
+           ng-class="{ flipped: card.visible_face == 'back' }">
+        <div class="front face">Front face</div>
+        <div class="back face">Back face</div>
+      </div>
+    </div>
+
+    <button ng-click='card.flip()'>
+        Flip card
+    </button>
+
+    <style>
+        .container {
+            width: 200px;
+            height: 260px;
+            position: relative;
+            -webkit-perspective: 800px;
+        }
+
+        #card {
+          width: 100%;
+          height: 100%;
+          position: absolute;
+          -webkit-transform-style: preserve-3d;
+          -webkit-transition: -webkit-transform 1s;
+        }
+
+        #card .face {
+          display: block;
+          position: absolute;
+          width: 100%;
+          height: 100%;
+          -webkit-backface-visibility: hidden;
+          color: white;
+          font-size: 16px;
+          margin-left: auto;
+          margin-right: auto;
+        }
+
+        #card .front {
+          background: red;
+        }
+
+        #card .back {
+          background: blue;
+          -webkit-transform: rotateY( 180deg );
+        }
+
+        #card.flipped {
+          -webkit-transform: rotateY( 180deg );
+        }
+    </style>
+"""
+
+template = Template(body_html=body_html)
+
+#### Entry point ####
+
+def main():
+    # Start a QtGui application
+    app = QtGui.QApplication([])
+
+    # Instantiate the domain model
+    card = Card()
+
+    # Create a jigna based HTML widget to render the HTML template with the
+    # given context.
+    widget = HTMLWidget(
+        template=template, context={'card': card}
+    )
+    widget.show()
+
+    # Start the event loop
+    app.exec_()
+
+if __name__ == "__main__":
+    main()
+
+#### EOF ######################################################################

--- a/examples/css_3d_transforms.py
+++ b/examples/css_3d_transforms.py
@@ -60,11 +60,9 @@ body_html = """
           position: absolute;
           width: 100%;
           height: 100%;
-          -webkit-backface-visibility: hidden;
           color: white;
           font-size: 16px;
-          margin-left: auto;
-          margin-right: auto;
+          -webkit-backface-visibility: hidden;
         }
 
         #card .front {

--- a/jigna/core/proxy_qwebview.py
+++ b/jigna/core/proxy_qwebview.py
@@ -17,7 +17,7 @@ from jigna.qt import QtCore, QtGui, QtWebKit
 logger = logging.getLogger(__name__)
 
 
-class ProxyQWebView(QtWebKit.QWebView):
+class ProxyQWebView(QtWebKit.QGraphicsWebView):
 
     DISABLED_ACTIONS = [
         QtWebKit.QWebPage.OpenLinkInNewWindow,

--- a/jigna/html_widget.py
+++ b/jigna/html_widget.py
@@ -36,10 +36,9 @@ class HTMLWidget(QtGui.QWidget):
         self._view.setHorizontalScrollBarPolicy(QtCore.Qt.ScrollBarAlwaysOff)
 
         self.webview = self._create_qwebview()
-        self.webview.resize(*template.recommended_size)
         self._scene.addItem(self.webview)
 
-        self._view.resize(*template.recommended_size)
+        self.resize(*template.recommended_size)
 
     def execute_js(self, js):
         """ Execute the given js string on the HTML widget.
@@ -60,3 +59,7 @@ class HTMLWidget(QtGui.QWidget):
         )
 
         return server.webview
+
+    def resizeEvent(self, event):
+        self.webview.resize(event.size())
+        self._view.resize(event.size())

--- a/jigna/html_widget.py
+++ b/jigna/html_widget.py
@@ -12,7 +12,7 @@ import os
 from os.path import join
 
 # Local Library
-from .qt import QtGui
+from .qt import QtGui, QtCore
 from .qt_server import QtServer
 
 
@@ -28,13 +28,18 @@ class HTMLWidget(QtGui.QWidget):
         self.context = context
         self.template = template
 
-        self.webview = self._create_qwebview()
-
         # Set the layout
-        self.setLayout(QtGui.QVBoxLayout())
-        self.layout().setContentsMargins(0, 0, 0, 0)
-        self.layout().addWidget(self.webview)
-        self.resize(*template.recommended_size)
+        self._scene = QtGui.QGraphicsScene()
+        self._view = QtGui.QGraphicsView(self._scene, parent=self)
+        self._view.setFrameShape(QtGui.QFrame.NoFrame)
+        self._view.setVerticalScrollBarPolicy(QtCore.Qt.ScrollBarAlwaysOff)
+        self._view.setHorizontalScrollBarPolicy(QtCore.Qt.ScrollBarAlwaysOff)
+
+        self.webview = self._create_qwebview()
+        self.webview.resize(*template.recommended_size)
+        self._scene.addItem(self.webview)
+
+        self._view.resize(*template.recommended_size)
 
     def execute_js(self, js):
         """ Execute the given js string on the HTML widget.

--- a/jigna/html_widget.py
+++ b/jigna/html_widget.py
@@ -34,7 +34,7 @@ class HTMLWidget(QtGui.QGraphicsView):
         scene.addItem(self.webview)
         self.setScene(scene)
 
-        # Layout the view
+        # Layout the graphics view
         self.setFrameShape(QtGui.QFrame.NoFrame)
         self.setVerticalScrollBarPolicy(QtCore.Qt.ScrollBarAlwaysOff)
         self.setHorizontalScrollBarPolicy(QtCore.Qt.ScrollBarAlwaysOff)
@@ -44,6 +44,9 @@ class HTMLWidget(QtGui.QGraphicsView):
         """ Execute the given js string on the HTML widget.
         """
         return self.webview.execute_js(js)
+
+    def resizeEvent(self, event):
+        self.webview.resize(event.size())
 
     #### Private protocol #####################################################
 
@@ -59,6 +62,3 @@ class HTMLWidget(QtGui.QGraphicsView):
         )
 
         return server.webview
-
-    def resizeEvent(self, event):
-        self.webview.resize(event.size())

--- a/jigna/html_widget.py
+++ b/jigna/html_widget.py
@@ -16,7 +16,7 @@ from .qt import QtGui, QtCore
 from .qt_server import QtServer
 
 
-class HTMLWidget(QtGui.QWidget):
+class HTMLWidget(QtGui.QGraphicsView):
     """ A Qt based HTML widget to render the jigna template with a given
     domain model context. """
 
@@ -28,16 +28,16 @@ class HTMLWidget(QtGui.QWidget):
         self.context = context
         self.template = template
 
-        # Set the layout
-        self._scene = QtGui.QGraphicsScene()
-        self._view = QtGui.QGraphicsView(self._scene, parent=self)
-        self._view.setFrameShape(QtGui.QFrame.NoFrame)
-        self._view.setVerticalScrollBarPolicy(QtCore.Qt.ScrollBarAlwaysOff)
-        self._view.setHorizontalScrollBarPolicy(QtCore.Qt.ScrollBarAlwaysOff)
-
+        # Set the scene
+        scene = QtGui.QGraphicsScene()
         self.webview = self._create_qwebview()
-        self._scene.addItem(self.webview)
+        scene.addItem(self.webview)
+        self.setScene(scene)
 
+        # Layout the view
+        self.setFrameShape(QtGui.QFrame.NoFrame)
+        self.setVerticalScrollBarPolicy(QtCore.Qt.ScrollBarAlwaysOff)
+        self.setHorizontalScrollBarPolicy(QtCore.Qt.ScrollBarAlwaysOff)
         self.resize(*template.recommended_size)
 
     def execute_js(self, js):
@@ -62,4 +62,3 @@ class HTMLWidget(QtGui.QWidget):
 
     def resizeEvent(self, event):
         self.webview.resize(event.size())
-        self._view.resize(event.size())

--- a/jigna/tests/test_html_widget.py
+++ b/jigna/tests/test_html_widget.py
@@ -26,7 +26,7 @@ class TestHTMLWidget(unittest.TestCase):
         # Check if a qwebview widget was created
         self.assertIsNotNone(widget)
         self.assertIsInstance(widget, QtGui.QWidget)
-        self.assertIsInstance(widget.webview, QtWebKit.QWebView)
+        self.assertIsInstance(widget.webview, QtWebKit.QGraphicsWebView)
 
     def test_created_widget_loads_html(self):
         # Create a widget


### PR DESCRIPTION
This PR changes the internal webview class from QtWebKit.QWebView to QtWebKit.QGraphicsWebView, which supports CSS 3D transforms and other cool graphics features.

In order to display a QGraphicsWebView, we need to wrap it within a QGraphicsView object. We do that by making our HTMLWidget a QGraphicsView itself. This works seamlessly because QGraphicsView is a subclass of QWidget.  