### PR TITLE
Templating: Don't use file urls

### DIFF
--- a/examples/template_person.html
+++ b/examples/template_person.html
@@ -1,0 +1,4 @@
+<div>
+    Name: {{person.name}}
+    Age:  {{person.age}}
+</div>

--- a/examples/template_person.html
+++ b/examples/template_person.html
@@ -1,4 +1,3 @@
 <div>
-    Name: {{person.name}}
-    Age:  {{person.age}}
+    {{person.name}}, {{person.age}} years old.
 </div>

--- a/examples/templating.js
+++ b/examples/templating.js
@@ -1,0 +1,12 @@
+var app = angular.module('templating', ['jigna']);
+
+app.run(function(){
+    jigna.initialize();
+})
+
+app.directive('personView', function(){
+    return {
+        scope: {person: '='},
+        templateUrl: 'template_person.html'
+    }
+})

--- a/examples/templating.py
+++ b/examples/templating.py
@@ -18,14 +18,14 @@ class Person(HasTraits):
 #### UI layer ####
 
 html = """
-  <html ng-app='jigna'>
+  <html ng-app='templating'>
     <head>
       <script type='text/javascript' src='/jigna/jigna.js'></script>
-      <script type='text/javascript'>jigna.initialize()</script>
+      <script type='text/javascript' src='templating.js'></script>
     </head>
     <body>
-      Person:
-      <div ng-include="'template_person.html'"></div>
+      <person-view person="fred"></person-view>
+      <person-view person="wilma"></person-view>
     </body>
   </html>
 """
@@ -43,10 +43,13 @@ def main():
 
     # Instantiate the domain model
     fred = Person(name='Fred', age=28)
+    wilma = Person(name='Wilma', age=25)
 
     # Create the jigna based HTML widget which renders the given HTML template
     # with the given context.
-    widget = HTMLWidget(template=template, context={'person': fred})
+    widget = HTMLWidget(
+        template=template, context={'fred': fred, 'wilma': wilma}
+    )
     widget.show()
 
     # Start the event loop.
@@ -55,15 +58,6 @@ def main():
     # pulled in properly from the `user_resources_data` directory and displayed
     # in the view.
     app.exec_()
-
-
-def main2():
-    from jigna.utils.web import start_web_app
-
-    # Instantiate the domain model
-    fred = Person(name='Fred', age=28)
-
-    start_web_app(template=template, context={'person': fred})
 
 if __name__ == "__main__":
     main()

--- a/examples/templating.py
+++ b/examples/templating.py
@@ -1,0 +1,71 @@
+"""
+This example shows how to include HTML templates for creating reusable
+components.
+"""
+
+#### Imports ####
+
+from traits.api import HasTraits, Int, Str
+from jigna.api import HTMLWidget, Template
+from jigna.qt import QtGui
+
+#### Domain model ####
+
+class Person(HasTraits):
+    name = Str
+    age  = Int
+
+#### UI layer ####
+
+html = """
+  <html ng-app='jigna'>
+    <head>
+      <script type='text/javascript' src='/jigna/jigna.js'></script>
+      <script type='text/javascript'>jigna.initialize()</script>
+    </head>
+    <body>
+      Person:
+      <div ng-include="'template_person.html'"></div>
+    </body>
+  </html>
+"""
+
+# The base_url field specifies where to look when trying to get external
+# resources(defaults to an empty string, i.e. the current directory)
+template = Template(html=html)
+
+#### Entry point ####
+
+
+def main():
+    # Start the Qt application
+    app = QtGui.QApplication([])
+
+    # Instantiate the domain model
+    fred = Person(name='Fred', age=28)
+
+    # Create the jigna based HTML widget which renders the given HTML template
+    # with the given context.
+    widget = HTMLWidget(template=template, context={'person': fred})
+    widget.show()
+
+    # Start the event loop.
+    #
+    # You should see that user resources like CSS, images and custom JS are
+    # pulled in properly from the `user_resources_data` directory and displayed
+    # in the view.
+    app.exec_()
+
+
+def main2():
+    from jigna.utils.web import start_web_app
+
+    # Instantiate the domain model
+    fred = Person(name='Fred', age=28)
+
+    start_web_app(template=template, context={'person': fred})
+
+if __name__ == "__main__":
+    main()
+
+#### EOF ######################################################################

--- a/examples/templating.py
+++ b/examples/templating.py
@@ -54,9 +54,8 @@ def main():
 
     # Start the event loop.
     #
-    # You should see that user resources like CSS, images and custom JS are
-    # pulled in properly from the `user_resources_data` directory and displayed
-    # in the view.
+    # You should see that the person-view component's template is rendered with
+    # the correct domain models.
     app.exec_()
 
 if __name__ == "__main__":

--- a/jigna/core/network_access.py
+++ b/jigna/core/network_access.py
@@ -73,6 +73,7 @@ class ProxyAccessManager(QtNetwork.QNetworkAccessManager):
             operation, request, data
         )
 
+
 class ProxyReply(QtNetwork.QNetworkReply):
     """ QNetworkReply subclass to send a specific request to local wsgi app.
     """

--- a/jigna/core/proxy_qwebview.py
+++ b/jigna/core/proxy_qwebview.py
@@ -48,11 +48,6 @@ class ProxyQWebView(QtWebKit.QWebView):
         for action in self.DISABLED_ACTIONS:
             self.pageAction(action).setVisible(False)
 
-        # Allow access to local URLs
-        self.page().settings().setAttribute(
-            QtWebKit.QWebSettings.LocalContentCanAccessRemoteUrls, True
-        )
-
         # Setup debug flag
         self.page().settings().setAttribute(
             QtWebKit.QWebSettings.DeveloperExtrasEnabled, debug

--- a/jigna/core/wsgi.py
+++ b/jigna/core/wsgi.py
@@ -54,7 +54,7 @@ class FileLoader(HasTraits):
             start_response(
                 '200 OK', [('Content-Type', '; '.join(guess_type(path)))]
             )
-            return self.overrides[path]
+            return [self.overrides[path]]
 
         # Continue, if the path wasn't handled by canned responses for special
         # paths
@@ -69,4 +69,4 @@ class FileLoader(HasTraits):
             )
             with open(path, 'rb') as f:
                 response = f.read()
-            return response
+            return [response]

--- a/jigna/core/wsgi.py
+++ b/jigna/core/wsgi.py
@@ -25,7 +25,12 @@ def guess_type(content):
             if not mimeInitialized:
                 mimetypes.init()
                 mimeInitialized = True
-    return mimetypes.guess_type(content)
+    guessed = mimetypes.guess_type(content)
+
+    if guessed[1] is None:
+        guessed = (guessed[0], "")
+
+    return guessed
 
 
 class FileLoader(HasTraits):
@@ -33,21 +38,35 @@ class FileLoader(HasTraits):
     #: Root directory where it looks
     root = Directory
 
+    #: A dictionary of overrides which holds canned responses for some special
+    #: paths
+    overrides = Dict
+
     #### WSGI protocol ########################################################
 
     def __call__(self, env, start_response):
 
-        path = env['PATH_INFO'].strip('/')
-        path = '/'.join(path.split('/')[1:]) # remove the top-level path as that's url pattern
-        path = path.replace('/', sep)        # handle Windows paths
-        path = join(self.root, path)
+        # Clean up path and handle Windows paths
+        path = env['PATH_INFO'].strip('/').replace('/', sep)
 
+        # Check if it is handled by one of the overrides
+        if self.overrides.get(path) is not None:
+            start_response(
+                '200 OK', [('Content-Type', '; '.join(guess_type(path)))]
+            )
+            return self.overrides[path]
+
+        # Continue, if the path wasn't handled by canned responses for special
+        # paths
+        path = join(self.root, path)
         if not exists(path):
             start_response('404 File not found', [])
             return ""
 
         else:
-            start_response('200 OK', [('Content-Type', guess_type(path))])
+            start_response(
+                '200 OK', [('Content-Type', '; '.join(guess_type(path)))]
+            )
             with open(path, 'rb') as f:
                 response = f.read()
             return response

--- a/jigna/core/wsgi.py
+++ b/jigna/core/wsgi.py
@@ -61,7 +61,7 @@ class FileLoader(HasTraits):
         path = join(self.root, path)
         if not exists(path):
             start_response('404 File not found', [])
-            return ""
+            return [""]
 
         else:
             start_response(

--- a/jigna/server.py
+++ b/jigna/server.py
@@ -52,6 +52,9 @@ class Server(HasTraits):
     def _set_base_url(self, base_url):
         self._base_url = base_url
 
+    #: URL for the main home page
+    home_url = Str('http://root.jigna/index.html')
+
     #: The html to serve.
     html = Str
 

--- a/jigna/utils/web.py
+++ b/jigna/utils/web.py
@@ -30,3 +30,20 @@ def get_free_port():
     sock.close()
 
     return port
+
+
+def start_web_app(template, context, port=8000):
+    """
+    Start a web app at the given port for serving the jigna view for the given
+    template and context.
+    """
+    from tornado.ioloop import IOLoop
+    from jigna.api import WebApp
+
+    ioloop = IOLoop.instance()
+
+    app = WebApp(template=template, context=context)
+    app.listen(port)
+
+    print 'Starting the web app on port %s ...' % port
+    ioloop.start()

--- a/jigna/web_server.py
+++ b/jigna/web_server.py
@@ -11,7 +11,7 @@
 # Standard library.
 import json
 import mimetypes
-from os.path import join, dirname
+from os.path import abspath, dirname, join
 import traceback
 
 # 3rd party library.
@@ -23,6 +23,9 @@ from traits.api import List, Str, Instance
 
 # Jigna library.
 from jigna.server import Bridge, Server
+
+#: Path to jigna.js file
+JIGNA_JS_FILE = join(abspath(dirname(__file__)), 'js', 'dist', 'jigna.js')
 
 
 class WebBridge(Bridge):
@@ -83,7 +86,7 @@ class WebServer(Server):
             # To serve jigna.js from package source
             (
                 r"/jigna/(.*)", StaticFileHandler,
-                dict(path=join(dirname(__file__), 'js', 'dist'))
+                dict(path=dirname(JIGNA_JS_FILE))
             ),
 
             # This handler handles the web socket based async version of the


### PR DESCRIPTION
This PR makes sure we don't use file URLs for setting up the HTML. This makes sure we don't run into a host of security issues present with file URLs eg. loading external templates via ng-include.

Requires https://github.com/enthought/jigna/tree/better-proxies to be merged first