### PR TITLE
Fix py3 bug

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,8 @@ before_install:
   - if [[ ${TRAVIS_OS_NAME} == "linux" ]] ; then sh -e /etc/init.d/xvfb start ; fi
 install:
   - ./ci/travis_ci_bootstrap.sh
-  - edm install -y pip traits tornado nose coverage mock
+  - edm install --version $RUNTIME -y pip traits tornado nose coverage mock
+  - edm run -- python -V # Check the default Python version.
   - edm run -- pip install -U selenium  # Need latest selenium for browser support
   - for QT_API in $QT_APIS; do edm install -y $QT_API; done
   - edm run -- pip install -e .

--- a/jigna/server.py
+++ b/jigna/server.py
@@ -320,7 +320,7 @@ class Server(HasTraits):
                 type_name       = type_name,
                 attribute_names = self._get_attribute_names(obj),
                 event_names     = self._get_event_names(obj),
-                method_names    = self._get_public_method_names(type(obj))
+                method_names    = self._get_public_method_names(obj)
             )
             self._visited_type_names.add(type_name)
 
@@ -337,13 +337,13 @@ class Server(HasTraits):
 
         return dict(length=len(obj))
 
-    def _get_public_method_names(self, cls):
+    def _get_public_method_names(self, obj):
         """ Get the names of all public methods on a class.
 
         Return a list of strings.
 
         """
-
+        cls = type(obj)
         public_method_names = []
         for c in inspect.getmro(cls):
             if c is HasTraits:
@@ -351,7 +351,7 @@ class Server(HasTraits):
 
             for name in c.__dict__:
                 if not name.startswith( '_' ):
-                    value = getattr(c, name)
+                    value = getattr(obj, name)
                     if inspect.ismethod(value):
                         public_method_names.append(name)
 

--- a/jigna/tests/test_jigna_vue_web.py
+++ b/jigna/tests/test_jigna_vue_web.py
@@ -16,7 +16,7 @@ except ImportError:
 # Local imports.
 from jigna.utils.web import get_free_port
 from .test_jigna_web import TestJignaWebSync, Person, AddressBook, \
-    patch_sys_modules
+    patch_sys_modules, start_io_loop
 from .test_jigna_vue_qt import body_vue_html
 
 
@@ -26,7 +26,6 @@ class TestJignaVueWebSync(TestJignaWebSync):
         cls._backup_modules = patch_sys_modules()
         from jigna.vue_template import VueTemplate
         from jigna.web_app import WebApp
-        ioloop = IOLoop.instance()
         fred = Person(name='Fred', age=42)
         addressbook = AddressBook()
         template = VueTemplate(body_html=body_vue_html, async=async)
@@ -40,7 +39,7 @@ class TestJignaVueWebSync(TestJignaWebSync):
 
         # Start the tornado server in a different thread so that we can write
         # test statements here in the main loop
-        t = Thread(target=ioloop.start)
+        t = Thread(target=start_io_loop)
         t.setDaemon(True)
         t.start()
 


### PR DESCRIPTION
- Fix issue with travis builds using wrong Python!  They were all running 2.7.
- Fix real problem with Python3 where callables were not being passed to the JS side.
- Improve test stability by running the ioloop a little more carefully in the right thread and shutting it down carefully.