### PR TITLE
Fix bdist_egg build

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,4 +4,4 @@ recursive-include jigna/js *.*
 recursive-exclude jigna/js/node_modules *.*
 recursive-exclude examples/.ipynb_checkpoints *.*
 include README.rst LICENSE.txt
-global-exclude *.pyc *.pyo .DS_Store *.egg-info/*
+global-exclude *.pyc *.pyo .DS_Store


### PR DESCRIPTION
The current manifest will remove the egg-info directory created during the build as a result the zipped egg will not have a properly populated `EGG-INFO` folder.


